### PR TITLE
Introduce contribution guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,6 +37,7 @@ Before submitting your PR, validate your changes:
 docker run --rm --platform=linux/amd64 \
   -e RUN_LOCAL=true \
   -e DEFAULT_BRANCH=main \
+  -e VALIDATE_GITHUB_ACTIONS_ZIZMOR=false \
   -v "$(git rev-parse --show-toplevel)":/tmp/lint \
   ghcr.io/super-linter/super-linter:latest
 ```
@@ -44,6 +45,8 @@ docker run --rm --platform=linux/amd64 \
 The `--platform=linux/amd64` flag provides compatibility on Apple Silicon Macs, until super-linter supports ARM natively.
 
 For automatic fixes to common issues, see super-linter's [automatic fixing documentation][autofix].
+
+This "ZIZMOR" pedantic GHA analyzer is disabled because it is overly strict.
 
 [super-linter]: https://github.com/super-linter/super-linter
 [autofix]: https://github.com/super-linter/super-linter#how-to-use-fix-mode

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,6 +37,7 @@ Before submitting your PR, validate your changes:
 docker run --rm --platform=linux/amd64 \
   -e RUN_LOCAL=true \
   -e DEFAULT_BRANCH=main \
+  -e LOG_LEVEL=WARN \
   -e VALIDATE_GITHUB_ACTIONS_ZIZMOR=false \
   -v "$(git rev-parse --show-toplevel)":/tmp/lint \
   -v "$(git rev-parse --git-common-dir)":"$(git rev-parse --git-common-dir)" \
@@ -46,6 +47,8 @@ docker run --rm --platform=linux/amd64 \
 The `--platform=linux/amd64` flag provides compatibility on Apple Silicon Macs, until super-linter supports ARM natively.
 
 When working with worktrees, you'll need to mount the worktree directory as a volume in the Docker container.
+
+Setting `LOG_LEVEL=WARN` will reduce the verbosity of the linter output, making it easier to focus on relevant issues. Likewise, `LOG_LEVEL=DEBUG` can be used for more detailed output when troubleshooting.
 
 For automatic fixes to common issues, see super-linter's [automatic fixing documentation][autofix].
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -39,10 +39,13 @@ docker run --rm --platform=linux/amd64 \
   -e DEFAULT_BRANCH=main \
   -e VALIDATE_GITHUB_ACTIONS_ZIZMOR=false \
   -v "$(git rev-parse --show-toplevel)":/tmp/lint \
+  -v "$(git rev-parse --git-common-dir)":"$(git rev-parse --git-common-dir)" \
   ghcr.io/super-linter/super-linter:latest
 ```
 
 The `--platform=linux/amd64` flag provides compatibility on Apple Silicon Macs, until super-linter supports ARM natively.
+
+When working with worktrees, you'll need to mount the worktree directory as a volume in the Docker container.
 
 For automatic fixes to common issues, see super-linter's [automatic fixing documentation][autofix].
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing
+
+:wave: Hi there!
+
+We're thrilled that you'd like to contribute to this project. Your help is
+essential for keeping it great.
+
+## Submitting a pull request
+
+We use [pull requests][open-prs] to contribute new features, fixes, or
+documentation.
+
+[open-prs]: https://github.com/notorious-go/sync/pulls
+
+Here are a few things you can do that will increase the likelihood of your pull
+request being accepted:
+
+- Keep your change as focused as possible. If there are multiple changes you
+  would like to make that are not dependent upon each other, submit them as
+  separate pull requests.
+- Write [descriptive commit messages][commit-format]. Review the Git history to
+  get a feel for it.
+
+[commit-format]: https://go.dev/wiki/CommitMessage
+
+Draft pull requests are also welcome to get feedback early on, or if there is
+something blocking you.
+
+## Resources
+
+- [Go `sync` package][]
+- [Go additional `x/sync` primitives][]
+- [How to Contribute to Open Source][]
+- [Using Pull Requests][]
+- [GitHub Help][]
+
+[Go `sync` package]: https://pkg.go.dev/sync
+[Go additional `x/sync` primitives]: https://pkg.go.dev/golang.org/x/sync
+[How to Contribute to Open Source]: https://opensource.guide/how-to-contribute/
+[Using Pull Requests]: https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests
+[GitHub Help]: https://docs.github.com/en

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,6 +26,28 @@ request being accepted:
 Draft pull requests are also welcome to get feedback early on, or if there is
 something blocking you.
 
+## Running super-linter locally
+
+All pull requests are validated with [super-linter][]. Since super-linter runs
+via Docker, you'll need Docker installed to run it locally.
+
+Before submitting your PR, validate your changes:
+
+```bash
+docker run --rm --platform=linux/amd64 \
+  -e RUN_LOCAL=true \
+  -e DEFAULT_BRANCH=main \
+  -v "$(git rev-parse --show-toplevel)":/tmp/lint \
+  ghcr.io/super-linter/super-linter:latest
+```
+
+The `--platform=linux/amd64` flag provides compatibility on Apple Silicon Macs, until super-linter supports ARM natively.
+
+For automatic fixes to common issues, see super-linter's [automatic fixing documentation][autofix].
+
+[super-linter]: https://github.com/super-linter/super-linter
+[autofix]: https://github.com/super-linter/super-linter#how-to-use-fix-mode
+
 ## Resources
 
 - [Go `sync` package][]

--- a/README.md
+++ b/README.md
@@ -72,12 +72,18 @@ require (
 
 ## Contributing
 
-Contributions should follow standard Go practices:
+Please read our [Contribution guidelines][] before submitting new Pull-Requests.
 
-- Code style follows the [Google Go Style Guide](https://google.github.io/styleguide/go/)
-- Commit messages follow conventional format
+In a nutshell, contributions should follow standard Go practices:
+
+- Code style follows the [Google Go Style Guide][]
+- Commit messages follow [Go commit format][]
 - All code must include tests and documentation
-- Run `go fmt`, `go vet`, and `go test` before submitting
+- Run the standard go tools (`go test`, `go fmt`, etc.) before submitting
+
+[Contribution guidelines]: ./.github/CONTRIBUTING.md
+[Google Go Style Guide]: https://google.github.io/styleguide/go/
+[Go commit format]: https://go.dev/wiki/CommitMessage
 
 ## License
 


### PR DESCRIPTION
As this project grows and habits become norms, it's becoming clear that we need a structured way to guide contributions. This PR introduces foundational contribution guidelines to help maintain consistency and quality across the codebase.

The motivation here is simple: good projects thrive on good contributions, and good contributions come from clear expectations. Without guidelines, contributors often hesitate or spend unnecessary time figuring out the project's conventions. This creates friction that we can easily avoid.

## Context

While working on recent refactoring efforts, I noticed we're following certain patterns and conventions implicitly - the Go commit message format, the Google Go Style Guide, our multi-module structure. These are all excellent practices, but they live in our heads rather than in documentation. New contributors shouldn't have to reverse-engineer our standards from the git history.

Additionally, with the super-linter integration, contributors need to know how to validate their changes locally before submitting PRs. Running linters in CI is great, but discovering issues after pushing is frustrating and wastes everyone's time.

## What this enables

With these guidelines in place, contributors can:
- Understand our commit message expectations upfront
- Run the same validation locally that we run in CI
- Know where to look for examples and resources
- Feel confident their contributions align with project standards

This isn't about adding bureaucracy - it's about removing ambiguity. Clear guidelines mean less back-and-forth on PRs, faster reviews, and ultimately a healthier project.

## Notes

The super-linter configuration includes some opinionated choices (like disabling ZIZMOR) based on what makes sense for this project. We can always adjust these as we learn what works best for our workflow.