### PR TITLE
Introduce primitives to process events concurrently with respect to their causality

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ dependency bloat and allows you to import only the specific constructs you need.
 | Module                       | Docs                                                                                                                                              | Description                                             |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
 | **[semaphore](./semaphore)** | [![Go Reference](https://pkg.go.dev/badge/github.com/notorious-go/sync/semaphore.svg)](https://pkg.go.dev/github.com/notorious-go/sync/semaphore) | A counting semaphore for limiting the goroutine groups. |
+| **[ordering](./ordering)**   | [![Go Reference](https://pkg.go.dev/badge/github.com/notorious-go/sync/ordering.svg)](https://pkg.go.dev/github.com/notorious-go/sync/ordering)   | Causal ordering primitives for concurrent operations.   |
 
 ### Versioning with Git Tags
 

--- a/ordering/causalorder/causalorder.go
+++ b/ordering/causalorder/causalorder.go
@@ -1,0 +1,279 @@
+package causalorder
+
+import (
+	"sync"
+
+	"github.com/notorious-go/sync/ordering"
+)
+
+// chain represents a linked list of operations for a single key
+type chain struct {
+	head chan struct{}
+}
+
+// init ensures that the chain is ready to use
+func (c *chain) init() {
+	if c.head == nil {
+		c.head = make(chan struct{})
+		close(c.head)
+	}
+}
+
+// put sets the new head of the chain and returns the wait channel
+func (c *chain) put(done chan struct{}) <-chan struct{} {
+	c.init()
+	wait := c.head
+	c.head = done
+	return wait
+}
+
+// isHead checks if the given done channel is the current head of the chain
+func (c *chain) isHead(done chan struct{}) bool {
+	return c.head == done
+}
+
+// CausalOrder enforces causal ordering for operations with multiple
+// dependencies expressed as a directed acyclic graph. Operations can depend on
+// any number of keys and will only proceed once all their dependencies are
+// satisfied. This allows modelling complex dependency relationships while
+// maximizing concurrent execution of independent operations.
+//
+// Operations added via HappensAfter wait for the head operations of all
+// specified chain keys to be ready before proceeding. Operations with disjoint
+// sets of dependencies can be executed concurrently.
+//
+// This is the most flexible ordering strategy in the package, allowing
+// inter-operation dependencies to be expressed as a graph rather than a linear
+// chain.
+//
+// The CausalOrder is not safe for concurrent use. It must be used from a
+// single goroutine that is responsible for defining the dependency relationships
+// between operations. This ensures the causal ordering semantics are well-defined.
+//
+// The zero-value CausalOrder is ready to use.
+type CausalOrder[K comparable] struct {
+	// Makes the zero-value CausalOrder ready to use and concurrent-safe.
+	initOnce sync.Once
+	// We must protect the map of chains against concurrent access.
+	chains chan map[K]*chain
+}
+
+// acquire gets exclusive access to the chains map
+func (o *CausalOrder[K]) acquire() (chains map[K]*chain, release func()) {
+	o.initOnce.Do(func() {
+		o.chains = make(chan map[K]*chain, 1)
+		o.chains <- make(map[K]*chain)
+	})
+	chains = <-o.chains
+	release = func() { o.chains <- chains }
+	return chains, release
+}
+
+// put creates a new head for the chain associated with the given key using the
+// given done channel, and returns the wait channel
+func (o *CausalOrder[K]) put(key K, done chan struct{}) <-chan struct{} {
+	chains, release := o.acquire()
+	defer release()
+	if _, exists := chains[key]; !exists {
+		chains[key] = new(chain)
+	}
+	return chains[key].put(done)
+}
+
+// delete removes the chain for the given key if the done channel is the head
+func (o *CausalOrder[K]) delete(key K, done chan struct{}) {
+	chains, release := o.acquire()
+	defer release()
+	if c, ok := chains[key]; ok && c.isHead(done) {
+		delete(chains, key)
+	}
+}
+
+// HappensAfter returns an Operation that synchronizes after the operations
+// associated with the given keys have completed.
+func (o *CausalOrder[K]) HappensAfter(keys ...K) ordering.Operation {
+	if len(keys) == 0 {
+		// If no keys are provided, we can just return an Operation that is ready
+		// immediately and does not require any cleaning up.
+		return new(loneOperation)
+	}
+
+	if len(keys) == 1 {
+		// If only one key is provided, we can create a simpler operation
+		return o.singleKeyOperation(keys[0])
+	}
+
+	// If multiple keys are provided, we need to create a causal operation that will
+	// wait for all of them to become ready and signal completion for each of them
+	// when it is marked as complete.
+	return o.multiKeyOperation(keys)
+}
+
+// singleKeyOperation creates an operation for a single key dependency
+func (o *CausalOrder[K]) singleKeyOperation(key K) ordering.Operation {
+	chains, release := o.acquire()
+	defer release()
+
+	if _, exists := chains[key]; !exists {
+		chains[key] = new(chain)
+	}
+
+	done := make(chan struct{})
+	wait := chains[key].put(done)
+
+	return &singleKeyOp[K]{
+		wait:  wait,
+		done:  done,
+		key:   key,
+		order: o,
+	}
+}
+
+// multiKeyOperation creates an operation for multiple key dependencies
+func (o *CausalOrder[K]) multiKeyOperation(keys []K) ordering.Operation {
+	// All chains share the same completed channel, which is closed by Complete().
+	// Sharing the same channel avoids allocating a new channel for each node.
+	completed := make(chan struct{})
+	dependencies := make(map[K]<-chan struct{}, len(keys))
+
+	for _, key := range keys {
+		dependencies[key] = o.put(key, completed)
+	}
+
+	return &multiKeyOp[K]{
+		order:        o,
+		dependencies: dependencies,
+		completed:    completed,
+	}
+}
+
+// A loneOperation is an Operation that is ready immediately, and marking it as
+// complete affects no other Operation because it does not participate in any
+// specific chain.
+//
+// Its zero value is ready to use, and it only allocates channels when Ready() or
+// Completed() are called for the first time.
+type loneOperation struct {
+	init      sync.Once
+	ready     chan struct{}
+	completed chan struct{}
+	complete  sync.Once
+}
+
+func (o *loneOperation) initOnce() {
+	o.init.Do(func() {
+		o.ready = make(chan struct{})
+		close(o.ready) // Close the ready channel immediately, as this operation is ready to use.
+		o.completed = make(chan struct{})
+	})
+}
+
+func (o *loneOperation) Ready() <-chan struct{} {
+	o.initOnce()
+	return o.ready
+}
+
+func (o *loneOperation) Completed() <-chan struct{} {
+	o.initOnce()
+	return o.completed
+}
+
+func (o *loneOperation) Complete() {
+	o.complete.Do(func() {
+		o.initOnce()
+		close(o.completed)
+	})
+}
+
+// singleKeyOp is an operation with a single key dependency
+type singleKeyOp[K comparable] struct {
+	wait     <-chan struct{}
+	done     chan struct{}
+	doneOnce sync.Once
+	key      K
+	order    *CausalOrder[K]
+}
+
+func (o *singleKeyOp[K]) Ready() <-chan struct{} {
+	return o.wait
+}
+
+func (o *singleKeyOp[K]) Completed() <-chan struct{} {
+	return o.done
+}
+
+func (o *singleKeyOp[K]) Complete() {
+	o.doneOnce.Do(func() {
+		close(o.done)
+		o.order.delete(o.key, o.done)
+	})
+}
+
+// multiKeyOp is an operation with multiple key dependencies
+type multiKeyOp[K comparable] struct {
+	order        *CausalOrder[K]
+	dependencies map[K]<-chan struct{}
+	completed    chan struct{}
+	doneOnce     sync.Once
+	readyLazily  sync.Once
+	readyCh      chan struct{}
+}
+
+// Ready returns a channel that closes when all operations in the vector are
+// ready to proceed. It defers creating that channel for as long as possible to
+// increase the chance of short-circuiting the concurrent waiting goroutine,
+// thereby reducing memory usage and improving resource usage.
+func (o *multiKeyOp[K]) Ready() <-chan struct{} {
+	o.readyLazily.Do(func() {
+		o.readyCh = make(chan struct{})
+		if o.shortCircuit() {
+			// If all dependencies are already ready, we can close the ready channel
+			// immediately, without waiting for them in a separate goroutine.
+			close(o.readyCh)
+			return
+		}
+
+		// If not all dependencies are ready, we must wait for them in a goroutine to
+		// avoid blocking the caller.
+		go func() {
+			for _, wait := range o.dependencies {
+				<-wait
+			}
+			close(o.readyCh)
+		}()
+	})
+	return o.readyCh
+}
+
+func (o *multiKeyOp[K]) Completed() <-chan struct{} {
+	return o.completed
+}
+
+// shortCircuit checks if all dependencies are already ready
+func (o *multiKeyOp[K]) shortCircuit() bool {
+	for _, wait := range o.dependencies {
+		select {
+		case <-wait:
+		default:
+			// If even a single dependency is not immediately ready, then the short-circuiting
+			// is not possible, and we need to wait for all of them to become ready.
+			return false
+		}
+	}
+	return true
+}
+
+// Complete marks this operation as completed and cleans up chains
+func (o *multiKeyOp[K]) Complete() {
+	o.doneOnce.Do(func() {
+		// We must first close the completed channel before attempting to reclaim memory
+		// from the map of chains. Otherwise, we risk racing between the goroutine that
+		// called this method and another goroutine that is advancing chains.
+		close(o.completed)
+
+		// Clean up each chain if it's no longer necessary
+		for key := range o.dependencies {
+			o.order.delete(key, o.completed)
+		}
+	})
+}

--- a/ordering/causalorder/causalorder_test.go
+++ b/ordering/causalorder/causalorder_test.go
@@ -1,0 +1,130 @@
+package causalorder_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/notorious-go/sync/ordering/causalorder"
+	"github.com/notorious-go/sync/ordering/ordertest"
+)
+
+// This test verifies complex chains of operations (centered around "alice" and
+// "bob") to ensure that operations within the same chain correctly adhere to the
+// interface guarantees.
+func TestOperationInterface(t *testing.T) {
+	var order causalorder.CausalOrder[string]
+	t.Run("alice-in-chains", func(t *testing.T) {
+		first := order.HappensAfter("alice", "in", "chains")
+		second := order.HappensAfter("alice", "in", "chains")
+		ordertest.TestOperationInterface(t, first, second)
+	})
+	t.Run("bob-in-chains", func(t *testing.T) {
+		first := order.HappensAfter("bob", "in", "chains")
+		second := order.HappensAfter("bob", "in", "chains")
+		ordertest.TestOperationInterface(t, first, second)
+	})
+}
+
+// TestVectorOrdering tests CausalOrder with multiple overlapping dependencies.
+//
+// This test case processes the following events in the following order:
+//  1. (A∩1), which happens immediately.
+//  2. (B∩2), which happens immediately.
+//  3. (A∩2), which happens after (A∩1) and (B∩2).
+//  4. (B∩1), which happens after (A∩1) and (B∩2).
+//  5. (B∩2)′, which happens after (A∩2) and (B∩1), and transitively after (A∩1) and (B∩2).
+func TestVectorOrdering(t *testing.T) {
+	var ordering causalorder.CausalOrder[string]
+	events := []ordertest.Event{
+		{
+			Token:        "(A∩1)",
+			HappensAfter: nil,
+			Operation:    ordering.HappensAfter("A", "1"),
+		},
+		{
+			Token:        "(B∩2)",
+			HappensAfter: nil,
+			Operation:    ordering.HappensAfter("B", "2"),
+		},
+		{
+			Token:        "(A∩2)",
+			HappensAfter: []string{"(A∩1)", "(B∩2)"},
+			Operation:    ordering.HappensAfter("A", "2"),
+		},
+		{
+			Token:        "(B∩1)",
+			HappensAfter: []string{"(A∩1)", "(B∩2)"},
+			Operation:    ordering.HappensAfter("B", "1"),
+		},
+		{
+			Token: "(B∩2)′",
+			HappensAfter: []string{
+				"(A∩2)", "(B∩1)", // Direct dependencies.
+				"(A∩1)", "(B∩2)", // Transitive dependencies.
+			},
+			Operation: ordering.HappensAfter("B", "2"),
+		},
+	}
+	ordertest.Test(t, events)
+}
+
+// TestCausalOrderUnderStress tests CausalOrder with ~100 events
+// representing file operations in a version control system.
+//
+// The test generates:
+//   - 5 directory creation events (no dependencies)
+//   - 100 file version events (5 dirs × 4 files × 5 versions)
+//
+// Each file version depends on:
+//   - Its parent directory existing (e.g. "src/main-v1" needs "mkdir-src")
+//   - Its previous version if any (e.g. "src/main-v2" needs "src/main-v1")
+//
+// This creates a realistic CausalOrder scenario where operations share some
+// dependencies (directory) but maintain independent version chains per file.
+func TestCausalOrderUnderStress(t *testing.T) {
+	type fsChain struct {
+		Kind string // Either "dir" or "file".
+		Name string // Name of the directory or file.
+	}
+	var ordering causalorder.CausalOrder[fsChain]
+
+	// Generate events: each file has versions that depend on the directory being
+	// created and the previous version of the file.
+	var (
+		events []ordertest.Event
+
+		dirs     = []string{"src", "test", "docs", "lib", "bin"}
+		files    = []string{"main", "util", "config", "data"}
+		versions = 5
+	)
+
+	// Create directories first (no dependencies).
+	for _, dir := range dirs {
+		dirChain := fsChain{Kind: "dir", Name: dir}
+		dirToken := fmt.Sprintf("mkdir-%s", dir)
+		events = append(events, ordertest.Event{
+			Token:     dirToken,
+			Operation: ordering.HappensAfter(dirChain),
+		})
+
+		// Create file versions: each depends on its directory and previous version.
+		for _, file := range files {
+			fileChain := fsChain{Kind: "file", Name: file}
+			for v := 1; v <= versions; v++ {
+				token := fmt.Sprintf("%s/%s-v%d", dir, file, v)
+				deps := []string{dirToken}
+				if v > 1 {
+					deps = append(deps, fmt.Sprintf("%s/%s-v%d", dir, file, v-1))
+				}
+				events = append(events, ordertest.Event{
+					Token:        token,
+					HappensAfter: deps,
+					Operation:    ordering.HappensAfter(dirChain, fileChain),
+				})
+			}
+		}
+	}
+
+	t.Logf("Testing CausalOrder with %d events", len(events))
+	ordertest.Test(t, events)
+}

--- a/ordering/causalorder/dependencygraph.go
+++ b/ordering/causalorder/dependencygraph.go
@@ -1,0 +1,66 @@
+package causalorder
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/notorious-go/sync/ordering"
+	"github.com/notorious-go/sync/semaphore"
+)
+
+// A DependencyGraph is a collection of goroutines working on tasks that maintain a
+// complex order of execution based on multiple chains. Each task blocks until
+// all previously submitted tasks with any of the same chain keys have completed.
+//
+// Unlike Topic, which blocks only on tasks with the exact same partition key,
+// DependencyGraph blocks on tasks that share any common key, allowing for more complex
+// dependency relationships while still permitting concurrent execution of
+// completely independent operations.
+//
+// A zero DependencyGraph is valid and has no limit on the number of active goroutines.
+type DependencyGraph[K comparable] struct {
+	wg       sync.WaitGroup
+	sem      semaphore.Semaphore
+	ordering CausalOrder[K]
+}
+
+// Go calls the given function in a new goroutine. It blocks until the new
+// goroutine can be added without the number of active goroutines in the group
+// exceeding the configured limit.
+//
+// The new goroutine will block before calling f until all previously submitted
+// tasks that share any of the given chain keys have completed. Tasks that share
+// no common keys can execute concurrently.
+func (d *DependencyGraph[K]) Go(keys []K, f func()) {
+	op := d.ordering.HappensAfter(keys...)
+	d.sem.Acquire()
+	d.wg.Add(1)
+	go func() {
+		defer d.done(op)
+		<-op.Ready()
+		f()
+	}()
+}
+
+func (d *DependencyGraph[K]) done(op ordering.Operation) {
+	op.Complete()
+	d.sem.Release()
+	d.wg.Done()
+}
+
+// Wait blocks until all function calls from the Go method have returned.
+func (d *DependencyGraph[K]) Wait() {
+	d.wg.Wait()
+}
+
+// SetLimit limits the number of active goroutines in this group to at most n. A
+// negative value indicates no limit. A zero value will block any further calls
+// to Go.
+//
+// The limit must not be modified while any goroutines in the group are active.
+func (d *DependencyGraph[K]) SetLimit(n int) {
+	if len(d.sem) != 0 {
+		panic(fmt.Errorf("dependencygraph: modify limit while %v goroutines in the group are still active", len(d.sem)))
+	}
+	d.sem = semaphore.New(n)
+}

--- a/ordering/causalorder/dependencygraph_test.go
+++ b/ordering/causalorder/dependencygraph_test.go
@@ -1,0 +1,169 @@
+package causalorder_test
+
+import (
+	"fmt"
+
+	"github.com/notorious-go/sync/ordering/causalorder"
+)
+
+// This example demonstrates using DependencyGraph to build a C program with
+// complex dependencies, similar to a Makefile.
+func ExampleDependencyGraph() {
+	// The zero value of DependencyGraph is valid and has no limit on the number of
+	// active goroutines.
+	var m causalorder.DependencyGraph[string]
+	// The groups in this package are designed to limit the number of active
+	// goroutines.
+	//
+	// For this example, we set the limit to 1, which enables us to predict the order
+	// of the verification output. In production code, setting it to 1 does not make
+	// sense, as it would serialize all operations as if they were in a single
+	// goroutine.
+	m.SetLimit(1)
+
+	// Each operation declares what it produces (first element) and what it
+	// depends on (remaining elements). This creates a dependency graph similar
+	// to Make targets.
+	//
+	// The syntax mimics Makefile rules:
+	//
+	//	target: dependencies...
+	//	  recipe commands...
+
+	// Source files are the starting point of our build graph. They have no
+	// dependencies because they already exist.
+	//
+	// DependencyGraph will run all three of these operations immediately and in
+	// parallel (up to our limit). This demonstrates that DependencyGraph identifies
+	// and executes independent operations concurrently.
+	m.Go([]string{"server.c"}, func() {
+		fmt.Println("📄 server.c:")
+		fmt.Println("✅ (source file exists)")
+	})
+	m.Go([]string{"handler.c"}, func() {
+		fmt.Println("📄 handler.c:")
+		fmt.Println("✅ (source file exists)")
+	})
+	m.Go([]string{"main.c"}, func() {
+		fmt.Println("📄 main.c:")
+		fmt.Println("✅ (source file exists)")
+	})
+
+	// Compilation steps declare dependencies. Each object file needs its
+	// corresponding source file to exist before compilation can begin.
+	//
+	// DependencyGraph automatically waits for "server.c" to be available before
+	// running this operation. Once all source files are ready, these compilations
+	// can run in parallel since they don't depend on each other.
+	m.Go([]string{"server.o", "server.c"}, func() {
+		fmt.Println("🔨 server.o: server.c")
+		fmt.Println("     gcc -c server.c -o server.o")
+		fmt.Println("✅ Produced: server.o")
+	})
+
+	// Similarly, this operation waits for "handler.c" but can run in parallel with
+	// the compilation of "server.c" into "server.o" since they have no mutual
+	// dependencies. This is where the DependencyGraph shines - it automatically
+	// identifies parallelism opportunities in your dependency graph. handler.o:
+	// handler.c
+	m.Go([]string{"handler.o", "handler.c"}, func() {
+		fmt.Println("🔨 handler.o: handler.c")
+		fmt.Println("     gcc -c handler.c -o handler.o")
+		fmt.Println("✅ Produced: handler.o")
+	})
+
+	// This demonstrates a key DependencyGraph concept: "main.o" is a new chain that
+	// becomes available immediately after this operation completes.
+	//
+	// DependencyGraph tracks each unique string as a separate dependency chain. When
+	// we produce "main.o" here, we're establishing that chain for any future
+	// operations that need it (like the linking step below). Until this completes,
+	// any operation depending on "main.o" will wait.
+	m.Go([]string{"main.o", "main.c"}, func() {
+		fmt.Println("🔨 main.o: main.c")
+		fmt.Println("     gcc -c main.c -o main.o")
+		fmt.Println("✅ Produced: main.o")
+	})
+
+	// The linking step demonstrates DependencyGraph's power with multiple
+	// dependencies. This operation will not start until ALL three object files are
+	// ready.
+	//
+	// DependencyGraph handles this synchronization automatically - you just declare
+	// what you need, and DependencyGraph ensures proper ordering.
+	m.Go([]string{"app", "main.o", "server.o", "handler.o"}, func() {
+		fmt.Println("🔗 app: main.o server.o handler.o")
+		fmt.Println("     gcc -o app main.o server.o handler.o")
+		fmt.Println("✅ Produced: app (executable)")
+	})
+
+	// INTENTIONAL BUG: This demonstrates a common mistake - forgetting dependencies!
+	// Without specifying "app" as a dependency, this creates a "lone operation" that
+	// normally runs immediately, potentially testing before the app is built.
+	//
+	// The correct version would be:
+	//
+	//	m.Go([]string{"test", "app"}, ...)
+	//
+	// However, because we SetLimit(1) for predictable output, operations run
+	// sequentially regardless. In production code without this limit, this test
+	// would race with the build steps and likely fail.
+	m.Go([]string{""}, func() {
+		fmt.Println("🧪 test: app")
+		fmt.Println("     ./app --test")
+		fmt.Println("☑️ NOT Produced: test (though all tests passed)")
+	})
+
+	// This demonstrates transitive dependencies. While we only specify "app" and
+	// "test" as direct dependencies, DependencyGraph ensures all transitive
+	// dependencies are satisfied too.
+	//
+	// This means app.tar.gz won't be created until:
+	//
+	//	- All object files are compiled (transitive via "app")
+	//	- All source files exist (transitive via object files)
+	//	- The app is successfully built
+	//	- Tests have passed
+	//
+	// This is the power of DependencyGraph - you don't need to list every transitive
+	// dependency, just your immediate needs.
+	m.Go([]string{"app.tar.gz", "app", "test"}, func() {
+		fmt.Println("📦 app.tar.gz: app test")
+		fmt.Println("     tar -czf app.tar.gz app README.md")
+		fmt.Println("❎️ Produced: test (see bug above)")
+		fmt.Println("✅ Produced: app.tar.gz (ready to ship!)")
+	})
+
+	// After submitting all events, we wait for all goroutines in the matrix to
+	// complete.
+	m.Wait()
+	fmt.Println("🎉 Build complete! Run 'tar -tf app.tar.gz' to see contents.")
+
+	// Output:
+	// 📄 server.c:
+	// ✅ (source file exists)
+	// 📄 handler.c:
+	// ✅ (source file exists)
+	// 📄 main.c:
+	// ✅ (source file exists)
+	// 🔨 server.o: server.c
+	//      gcc -c server.c -o server.o
+	// ✅ Produced: server.o
+	// 🔨 handler.o: handler.c
+	//      gcc -c handler.c -o handler.o
+	// ✅ Produced: handler.o
+	// 🔨 main.o: main.c
+	//      gcc -c main.c -o main.o
+	// ✅ Produced: main.o
+	// 🔗 app: main.o server.o handler.o
+	//      gcc -o app main.o server.o handler.o
+	// ✅ Produced: app (executable)
+	// 🧪 test: app
+	//      ./app --test
+	// ☑️ NOT Produced: test (though all tests passed)
+	// 📦 app.tar.gz: app test
+	//      tar -czf app.tar.gz app README.md
+	// ❎️ Produced: test (see bug above)
+	// ✅ Produced: app.tar.gz (ready to ship!)
+	// 🎉 Build complete! Run 'tar -tf app.tar.gz' to see contents.
+}

--- a/ordering/causalorder/example_test.go
+++ b/ordering/causalorder/example_test.go
@@ -1,0 +1,168 @@
+package causalorder_test
+
+import (
+	"fmt"
+
+	"github.com/notorious-go/sync/ordering"
+	"github.com/notorious-go/sync/ordering/causalorder"
+)
+
+// This example demonstrates how CausalOrder models causal (i.e. happens-after)
+// dependencies between operations as a directed acyclic graph (DAG).
+//
+// CausalOrder allows operations to depend on multiple "chains" of causality.
+// Each chain is identified by a key (in this example, strings like "config" or
+// "data"). Operations within the same chain execute sequentially, while
+// operations in different chains can execute concurrently.
+func ExampleCausalOrder() {
+	// When using CausalOrder, users choose the type that identifies the chains
+	// of operations. In this example, we will use strings as keys.
+	//
+	// The zero value is ready to use.
+	var graph causalorder.CausalOrder[string]
+
+	// Helper function to check and display operation readiness.
+	checkStatus := func(name string, op ordering.Operation) {
+		if ordering.Completed(op) {
+			fmt.Printf("%s: completed\n", name)
+		} else if ordering.Ready(op) {
+			fmt.Printf("%s: ready\n", name)
+		} else {
+			fmt.Printf("%s: blocked\n", name)
+		}
+	}
+
+	// This case demonstrates an operation that has no dependencies.
+	{
+		fmt.Println("Case 1: Operation with no dependencies")
+
+		// When HappensAfter is called with no keys, the operation is immediately ready
+		// and doesn't participate in any causal chains.
+		op1 := graph.HappensAfter() // No keys = no dependencies.
+		defer op1.Complete()        // Always remember to Complete() operations!
+		checkStatus("op1", op1)
+
+		// Any operations that happen after "no dependencies" are also ready immediately,
+		// since there are still no previous operations to wait for.
+		op2 := graph.HappensAfter() // Still no dependencies.
+		defer op2.Complete()        // Always remember to Complete() operations!
+		checkStatus("op2", op2)
+	}
+
+	fmt.Println()
+
+	// This case demonstrates how operations with the same key form a chain and must
+	// execute in the order they were created.
+	{
+		fmt.Println("Case 2: Single chain operations")
+
+		// The first operation in any chain is immediately ready because there are no
+		// previous operations to wait for.
+		first := graph.HappensAfter("work")
+		checkStatus("first", first)
+
+		// The second operation with the same key ("work") must wait for the first
+		// operation to complete before it can proceed.
+		second := graph.HappensAfter("work")
+		checkStatus("second", second)
+
+		// Completing the first operation unblocks the second.
+		first.Complete()
+		checkStatus("second (after first completes)", second)
+		second.Complete() // Always remember to Complete() operations!
+	}
+
+	fmt.Println()
+
+	// This case demonstrates how a single operation may depend on multiple
+	// independent chains, allowing for maximal concurrency, within the constraints
+	// of the causal order.
+	{
+		fmt.Println("Case 3: Multi-chain coordination")
+
+		// Start two independent workflows: loading config and loading data. Since these
+		// use different keys, they can proceed concurrently.
+		loadConfig := graph.HappensAfter("config")
+		loadData := graph.HappensAfter("data")
+
+		// And add subsequent operations to each chain. These must wait for their
+		// respective "load" operations to complete.
+		//
+		// Different chains are useful for modelling independent pipelines that don't
+		// interfere with each other.
+		useConfig := graph.HappensAfter("config")
+		useData := graph.HappensAfter("data")
+
+		fmt.Println("Initial state:")
+		checkStatus(" loadConfig", loadConfig) // ready (first in its chain)
+		checkStatus(" useConfig", useConfig)   // blocked (waiting for loadConfig)
+		checkStatus(" loadData", loadData)     // ready (first in its chain)
+		checkStatus(" useData", useData)       // blocked (waiting for loadData)
+
+		// Completing loading configuration will unblock the next operation in the
+		// "config" chain, but it will not affect the "data" chain.
+		fmt.Println("After loading config:")
+		loadConfig.Complete()
+		checkStatus(" loadConfig", loadConfig) // now completed
+		checkStatus(" useConfig", useConfig)   // now ready
+		checkStatus(" loadData", loadData)     // still ready
+		checkStatus(" useData", useData)       // still blocked
+
+		// While the chains are independent, a new operation can be added that depends on
+		// both chains. This operation will wait for the latest operation in both
+		// "config" and "data" chains to be complete before it can proceed.
+		//
+		// For operations that depend on multiple chains simultaneously, use HappensAfter
+		// with multiple keys. Such operations are considered ready if and only if ALL
+		// the specified chains are ready.
+		combinedOp := graph.HappensAfter("config", "data")
+		defer combinedOp.Complete()            // The best practice is to defer Complete().
+		checkStatus(" combinedOp", combinedOp) // blocked (waiting for both chains)
+
+		fmt.Println("After loading data and using the config:")
+		loadData.Complete()
+		useConfig.Complete()
+		checkStatus(" useConfig", useConfig)   // now completed
+		checkStatus(" loadData", loadData)     // now completed
+		checkStatus(" useData", useData)       // now ready
+		checkStatus(" combinedOp", combinedOp) // still blocked (waiting for useData)
+
+		fmt.Println("After using data:")
+		useData.Complete()
+		checkStatus(" useData", useData) // now completed
+		// TODO: At this point, combinedOp is not immediately marked as ready because the internal state update happens
+		// 	asynchronously. This can and will be fixed in a future release.
+		checkStatus(" combinedOp", combinedOp) // now ready
+	}
+
+	// Output:
+	// Case 1: Operation with no dependencies
+	// op1: ready
+	// op2: ready
+	//
+	// Case 2: Single chain operations
+	// first: ready
+	// second: blocked
+	// second (after first completes): ready
+	//
+	// Case 3: Multi-chain coordination
+	// Initial state:
+	//  loadConfig: ready
+	//  useConfig: blocked
+	//  loadData: ready
+	//  useData: blocked
+	// After loading config:
+	//  loadConfig: completed
+	//  useConfig: ready
+	//  loadData: ready
+	//  useData: blocked
+	//  combinedOp: blocked
+	// After loading data and using the config:
+	//  useConfig: completed
+	//  loadData: completed
+	//  useData: ready
+	//  combinedOp: blocked
+	// After using data:
+	//  useData: completed
+	//  combinedOp: ready
+}

--- a/ordering/doc.go
+++ b/ordering/doc.go
@@ -82,7 +82,8 @@
 // # Concurrent Groups
 //
 // Each ordering package also provides a group type (Queue for totalorder,
-// Topic for partialorder) that combines ordering with goroutine lifecycle management:
+// Topic for partialorder, DependencyGraph for causalorder) that combines
+// ordering with goroutine lifecycle management:
 //
 //	var group pkg.GroupType
 //	group.SetLimit(10) // Max 10 concurrent goroutines

--- a/ordering/doc.go
+++ b/ordering/doc.go
@@ -81,8 +81,8 @@
 //
 // # Concurrent Groups
 //
-// Each ordering package also provides a group type (Queue for totalorder)
-// that combines ordering with goroutine lifecycle management:
+// Each ordering package also provides a group type (Queue for totalorder,
+// Topic for partialorder) that combines ordering with goroutine lifecycle management:
 //
 //	var group pkg.GroupType
 //	group.SetLimit(10) // Max 10 concurrent goroutines

--- a/ordering/doc.go
+++ b/ordering/doc.go
@@ -8,6 +8,7 @@
 //
 //   - totalorder: Enforces strict sequential ordering of all operations
 //   - partialorder: Enforces sequential ordering per key, allowing concurrent execution across keys
+//   - causalorder: Enforces complex dependency graphs with multiple dependencies per operation
 //
 // # Operation Interface
 //
@@ -69,4 +70,12 @@
 //	    op := order.HappensAfter(event.UserID)
 //	    go processUserEvent(op, event)
 //	}
+//
+// Use the causalorder package when the source contains complex dependencies on
+// dynamic/multiple previous operations:
+//
+//	var order causalorder.CausalOrder[string]
+//	// Operation depends on multiple prerequisites
+//	op := order.HappensAfter("auth", "data-load", "validation")
+//	go performComplexOperation(op)
 package ordering

--- a/ordering/doc.go
+++ b/ordering/doc.go
@@ -78,4 +78,19 @@
 //	// Operation depends on multiple prerequisites
 //	op := order.HappensAfter("auth", "data-load", "validation")
 //	go performComplexOperation(op)
+//
+// # Concurrent Groups
+//
+// Each ordering package also provides a group type (Queue for totalorder)
+// that combines ordering with goroutine lifecycle management:
+//
+//	var group pkg.GroupType
+//	group.SetLimit(10) // Max 10 concurrent goroutines
+//
+//	for _, task := range tasks {
+//	    group.Go(func() {
+//	        processTask(task)
+//	    })
+//	}
+//	group.Wait() // Wait for all tasks to complete
 package ordering

--- a/ordering/doc.go
+++ b/ordering/doc.go
@@ -22,6 +22,12 @@
 //	    // perform work
 //	}()
 //
+// The Await helper function simplifies the common pattern:
+//
+//	done := ordering.Await(op)
+//	defer done()
+//	// ... perform operation ...
+//
 // It is also common for workers to abort operations; most commonly cancelled
 // using context:
 //

--- a/ordering/doc.go
+++ b/ordering/doc.go
@@ -1,3 +1,37 @@
 // Package ordering provides synchronization primitives for managing the causal
 // ordering of concurrent operations.
+//
+// # Operation Interface
+//
+// The [Operation] interface is the core abstraction that all ordering strategies
+// build upon. It provides three methods:
+//
+//   - Ready(): Returns a channel that closes when the operation can begin
+//   - Complete(): Marks the operation as finished, unblocking dependent operations
+//   - Completed(): Returns a channel that closes when Complete() is called
+//
+// # Usage Patterns
+//
+// All ordering types follow a similar usage pattern:
+//
+//	var order OrderingType
+//	op := order.Schedule(...)
+//	go func() {
+//	    defer op.Complete()
+//	    <-op.Ready()
+//	    // perform work
+//	}()
+//
+// It is also common for workers to abort operations; most commonly cancelled
+// using context:
+//
+//	select {
+//	case <-op.Ready():
+//	    defer op.Complete()
+//	    // perform work
+//	    return nil
+//	case <-ctx.Done():
+//	    op.Complete() // Important: still call Complete
+//	    return ctx.Err()
+//	}
 package ordering

--- a/ordering/doc.go
+++ b/ordering/doc.go
@@ -1,0 +1,3 @@
+// Package ordering provides synchronization primitives for managing the causal
+// ordering of concurrent operations.
+package ordering

--- a/ordering/doc.go
+++ b/ordering/doc.go
@@ -7,6 +7,7 @@
 // ordering strategy:
 //
 //   - totalorder: Enforces strict sequential ordering of all operations
+//   - partialorder: Enforces sequential ordering per key, allowing concurrent execution across keys
 //
 // # Operation Interface
 //
@@ -57,5 +58,15 @@
 //	for _, task := range tasks {
 //	    op := order.HappensNext()
 //	    go processTask(op, task)
+//	}
+//
+// Use the partialorder package when the source contains partially ordered
+// events, wherein operations must be ordered within groups but can run
+// concurrently across groups:
+//
+//	var order partialorder.PartialOrder[string]
+//	for _, event := range events {
+//	    op := order.HappensAfter(event.UserID)
+//	    go processUserEvent(op, event)
 //	}
 package ordering

--- a/ordering/doc.go
+++ b/ordering/doc.go
@@ -10,6 +10,9 @@
 //   - partialorder: Enforces sequential ordering per key, allowing concurrent execution across keys
 //   - causalorder: Enforces complex dependency graphs with multiple dependencies per operation
 //
+// All ordering strategies implement the Operation interface, providing a uniform
+// API for synchronization regardless of the chosen strategy.
+//
 // # Operation Interface
 //
 // The [Operation] interface is the core abstraction that all ordering strategies
@@ -94,4 +97,22 @@
 //	    })
 //	}
 //	group.Wait() // Wait for all tasks to complete
+//
+// # Best Practices
+//
+// 1. Always call Complete(): Failing to call Complete() will block dependent operations
+// indefinitely, causing goroutine leaks.
+//
+// 2. Use defer: Always use `defer op.Complete()` immediately after Ready() to ensure
+// completion even if the operation panics.
+//
+// 3. Choose the right strategy: Use the simplest ordering that meets your needs.
+// CausalOrder is the most flexible and has little overhead, but run your own
+// benchmarks.
+//
+// 4. Consider memory usage: Chains are automatically cleaned up when no operations
+// are pending, but long-lived ordering objects with many keys may accumulate memory.
+//
+// 5. Single producer: The ordering objects are not safe for concurrent use. Define
+// a single order from a single goroutine.
 package ordering

--- a/ordering/doc.go
+++ b/ordering/doc.go
@@ -1,5 +1,12 @@
 // Package ordering provides synchronization primitives for managing the causal
-// ordering of concurrent operations.
+// ordering of concurrent operations. It offers ordering strategies that allow
+// developers to express different types of dependencies between operations
+// while maximizing concurrent execution where possible.
+//
+// The package is organized into sub-packages, each implementing a different
+// ordering strategy:
+//
+//   - totalorder: Enforces strict sequential ordering of all operations
 //
 // # Operation Interface
 //
@@ -39,5 +46,16 @@
 //	case <-ctx.Done():
 //	    op.Complete() // Important: still call Complete
 //	    return ctx.Err()
+//	}
+//
+// # Choosing an Ordering Strategy
+//
+// Use the totalorder package when the source of tasks is a totally ordered
+// stream, wherein each operation must happen strictly after the previous one.
+//
+//	var order totalorder.TotalOrder
+//	for _, task := range tasks {
+//	    op := order.HappensNext()
+//	    go processTask(op, task)
 //	}
 package ordering

--- a/ordering/go.mod
+++ b/ordering/go.mod
@@ -1,3 +1,5 @@
 module github.com/notorious-go/sync/ordering
 
 go 1.25
+
+require github.com/notorious-go/sync/semaphore v1.0.0 // indirect

--- a/ordering/go.mod
+++ b/ordering/go.mod
@@ -2,4 +2,4 @@ module github.com/notorious-go/sync/ordering
 
 go 1.25
 
-require github.com/notorious-go/sync/semaphore v1.0.0 // indirect
+require github.com/notorious-go/sync/semaphore v1.0.0

--- a/ordering/go.mod
+++ b/ordering/go.mod
@@ -1,0 +1,3 @@
+module github.com/notorious-go/sync/ordering
+
+go 1.25

--- a/ordering/go.sum
+++ b/ordering/go.sum
@@ -1,0 +1,2 @@
+github.com/notorious-go/sync/semaphore v1.0.0 h1:oxi/EnxDaPH4e91CTGFOtoJjilsJ8RkMGNwE5n5LFM8=
+github.com/notorious-go/sync/semaphore v1.0.0/go.mod h1:AxPfw4oOwMeDhnycQA3LJ7DGaajjMR0Qwj65+q+kPlg=

--- a/ordering/ordering.go
+++ b/ordering/ordering.go
@@ -80,3 +80,27 @@ func Completed(op Operation) (completed bool) {
 		return false
 	}
 }
+
+// Await is a convenience function that blocks until the given Operation is ready
+// to execute and returns a done function that must be called to mark the
+// operation as complete.
+//
+// This function provides syntactic sugar for the common pattern of waiting for
+// an operation to be ready and then marking it as complete:
+//
+//	done := ordering.Await(op)
+//	defer done()
+//	// ... perform operation ...
+//
+// This is equivalent to:
+//
+//	<-op.Ready()
+//	defer op.Complete()
+//	// ... perform operation ...
+//
+// The returned done function is safe to call multiple times and should always be
+// called to prevent blocking further operations in the causal chain.
+func Await(op Operation) (done func()) {
+	<-op.Ready()
+	return op.Complete
+}

--- a/ordering/ordering.go
+++ b/ordering/ordering.go
@@ -66,3 +66,17 @@ func Ready(op Operation) (ready bool) {
 		return false
 	}
 }
+
+// Completed checks whether the given operation has been completed.
+//
+// If the given operation is not completed, we say it is pending, meaning it is
+// either ready to be executed or blocking on some other operations to complete
+// before it can be executed.
+func Completed(op Operation) (completed bool) {
+	select {
+	case <-op.Completed():
+		return true
+	default:
+		return false
+	}
+}

--- a/ordering/ordering.go
+++ b/ordering/ordering.go
@@ -1,0 +1,55 @@
+package ordering
+
+// Operation represents a unit of work in a causally ordered execution chain. It
+// provides synchronization points for managing when an operation can begin and
+// signalling when it has completed.
+//
+// An Operation is the fundamental building block for enforcing "happens-after"
+// relationships in concurrent programs. Each Operation waits for its causal
+// dependencies to complete before becoming ready and signals its own completion
+// to unblock dependent operations.
+//
+// The Operation interface provides a channel-based API that enables flexible
+// synchronization patterns:
+//   - Block until ready using <-op.Ready()
+//   - Select with multiple channels: select { case <-op.Ready(): ... case <-ctx.Done(): ... }
+//   - Check readiness without blocking: select { case <-op.Ready(): ... default: ... }
+//   - Monitor completion: <-op.Completed()
+//
+// Operations are safe for concurrent use. While typically a single goroutine
+// manages an operation's lifecycle, the channels can be safely accessed from
+// multiple goroutines when coordination is needed.
+type Operation interface {
+	// Ready returns a channel that closes when all causal dependencies have
+	// completed, signalling that this operation may begin execution.
+	//
+	// The channel is closed exactly once and remains closed thereafter. Multiple
+	// goroutines may safely wait on this channel.
+	//
+	// For the first operation in a chain, this channel is closed immediately,
+	// allowing it to proceed without waiting.
+	Ready() <-chan struct{}
+
+	// Completed returns a channel that closes when this operation has been marked
+	// as complete via the Complete method.
+	//
+	// The channel is closed when Complete is called for the first time and
+	// remains closed thereafter.
+	Completed() <-chan struct{}
+
+	// Complete marks this operation as finished, closing the Completed channel and
+	// allowing any causally dependent operations to proceed.
+	//
+	// This method MUST be called at least once when the operation finishes, whether
+	// it succeeds, fails, or is cancelled. Failing to call Complete will cause all
+	// dependent operations to block indefinitely, potentially causing goroutine
+	// and memory leaks.
+	//
+	// Users are encouraged to use defer op.Complete() immediately after starting an
+	// operation to ensure completion even in case of errors or early returns.
+	//
+	// Complete is safe to call multiple times - subsequent calls are no-ops.
+	// However, for clarity and correctness, it should typically be called exactly
+	// once per operation.
+	Complete()
+}

--- a/ordering/ordering.go
+++ b/ordering/ordering.go
@@ -53,3 +53,16 @@ type Operation interface {
 	// once per operation.
 	Complete()
 }
+
+// Ready checks whether the given operation is ready to be executed.
+//
+// If the given operation is not ready, we say it is blocking, meaning it is
+// waiting for some other operations to complete before it can be executed.
+func Ready(op Operation) (ready bool) {
+	select {
+	case <-op.Ready():
+		return true
+	default:
+		return false
+	}
+}

--- a/ordering/ordering_test.go
+++ b/ordering/ordering_test.go
@@ -1,0 +1,125 @@
+package ordering_test
+
+import (
+	"fmt"
+	"slices"
+	"sync"
+
+	"github.com/notorious-go/sync/ordering"
+	"github.com/notorious-go/sync/ordering/totalorder"
+)
+
+// This example demonstrates how to determine the current status of an Operation
+// using select statements with the Ready and Completed channels.
+//
+// Typically, an Operation transitions through several states during its lifecycle:
+//
+//   - Initially, it is blocking, waiting for dependencies to complete.
+//   - Then, it becomes ready to execute when all dependencies are satisfied. After
+//     execution starts, it is in a pending state until it completes.
+//   - Finally, it is completed when the operation has finished executing.
+func ExampleOperation_status() {
+	// For this example, we will use a TotalOrder to create sequential operations,
+	// wherein op2 happens after op1.
+	var order totalorder.TotalOrder
+	op1 := order.HappensNext()
+	op2 := order.HappensNext()
+
+	// We will define helper functions to check the status of an operation.
+	checkStatus := func(op ordering.Operation) (status string) {
+		if ordering.Completed(op) {
+			// Technically, an operation can be completed without being ready, but this
+			// should not happen in well-behaved code.
+			if !ordering.Ready(op) {
+				return "completed (detached)"
+			}
+			return "completed"
+		}
+		// An operation that is pending until it is completed. While pending, it can be
+		// either ready to execute or blocking on dependent operations.
+		if ordering.Ready(op) {
+			return "pending (ready)"
+		}
+		return "pending (blocking)"
+	}
+
+	// Initial state: op1 is ready, op2 is blocking.
+	fmt.Println("op1:", checkStatus(op1))
+	fmt.Println("op2:", checkStatus(op2))
+
+	// After op1 completes, op2 becomes ready.
+	op1.Complete()
+	fmt.Println("op1:", checkStatus(op1))
+	fmt.Println("op2:", checkStatus(op2))
+
+	// After op2 completes, both operations are completed.
+	op2.Complete()
+	fmt.Println("op1:", checkStatus(op1))
+	fmt.Println("op2:", checkStatus(op2))
+
+	// Output:
+	// op1: pending (ready)
+	// op2: pending (blocking)
+	// op1: completed
+	// op2: pending (ready)
+	// op1: completed
+	// op2: completed
+}
+
+// This example demonstrates the use of the Await convenience function for simple
+// interactions with operations.
+//
+// Await is suitable for cases where you want to block until an operation is
+// ready and then execute it, without considering timeouts or cancellation.
+func ExampleAwait() {
+	// For this example, we will use a TotalOrder to create sequential operations.
+	var order totalorder.TotalOrder
+
+	// For this example, we will define a Task type that represents a causally
+	// ordered operation.
+	type Task struct {
+		Id int
+		ordering.Operation
+	}
+
+	// First, let's create three tasks that must execute in sequence.
+	var tasks []Task
+	for i := range 3 {
+		// Calling HappensNext() returns an ordering.Operation that is ready to be
+		// executed after all previous operations in our exemplar total order have
+		// completed.
+		//
+		// Note how the operations are ordered by the order we call HappensNext(), so it
+		// is never called concurrently. Once the order is established, we can execute
+		// the operations concurrently and still ensure they happen in the correct order.
+		t := Task{Id: i + 1, Operation: order.HappensNext()}
+		tasks = append(tasks, t)
+	}
+
+	// Though the total-order guarantees that operations will be executed in
+	// sequence, we still want to demonstrate the concurrent execution pattern.
+	//
+	// To prove the ordering guarantees of the total order, we will spawn tasks in
+	// reverse order, but they will still execute in the correct order due to the
+	// causality constraints.
+	var wg sync.WaitGroup
+	for _, t := range slices.Backward(tasks) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Await blocks until ready and returns a done function, which should be deferred
+			// to ensure the operation is marked as complete no matter what (yes, even panics).
+			done := ordering.Await(t)
+			defer done() // Always mark the operation as complete!
+
+			// -- simulate work --
+			fmt.Println("Executing operation", t.Id)
+		}()
+	}
+	wg.Wait()
+
+	// Output:
+	// Executing operation 1
+	// Executing operation 2
+	// Executing operation 3
+}

--- a/ordering/ordertest/ordertest.go
+++ b/ordering/ordertest/ordertest.go
@@ -1,0 +1,172 @@
+// Package ordertest provides utilities for testing causal ordering
+// implementations. The package offers a framework for verifying that concurrent
+// operations respect their declared dependencies when using orderings from the
+// ordering packages (e.g. totalorder, partialorder, and causalorder).
+//
+// # Overview
+//
+// The primary function [Test] executes a series of [Events] concurrently and
+// verifies that all dependency constraints are satisfied.
+//
+// # Example Usage
+//
+// Create a test case with dependencies:
+//
+//	var ordering OrderingType
+//	events := []ordertest.Event{
+//		{
+//			Token:        "user-create",
+//			HappensAfter: nil,
+//			Operation:    ordering.HappensAfter("user"),
+//		},
+//		{
+//			Token:        "user-login",
+//			HappensAfter: []string{"user-create"},
+//			Operation:    ordering.HappensAfter("user"),
+//		},
+//	}
+//	ordertest.Test(t, events)
+//
+// The test will verify that "user-login" only executes after "user-create" has
+// completed, even though the goroutines are spawned in reverse order.
+package ordertest
+
+import (
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/notorious-go/sync/ordering"
+)
+
+// Test executes an event-loop consisting of the predefined events concurrently
+// and verifies that all dependency constraints are satisfied.
+//
+// The function:
+//
+//   - Spawns a goroutine for each event in reverse order (to stress the ordering).
+//   - Each goroutine waits for its Operation to be ready before proceeding.
+//   - Records the actual execution order of events, which is the order in which
+//     the spawned goroutines are running.
+//   - Verifies that the declared order was satisfied using Event.Check.
+//
+// This helper is designed to test the correctness of TotalOrder, PartialOrder,
+// and CausalOrder implementations by ensuring that operations respect their
+// declared dependencies when executing concurrently.
+func Test(t *testing.T, events []Event) {
+	t.Helper()
+
+	var (
+		mu     sync.Mutex
+		tokens []string
+	)
+
+	var wg sync.WaitGroup
+	for _, event := range slices.Backward(events) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer event.Operation.Complete()
+
+			select {
+			case <-event.Operation.Ready():
+				// The operation is ready, meaning all dependencies are satisfied.
+				t.Logf("Processing event %s", event.Token)
+			case <-t.Context().Done():
+				t.Errorf("test interrupted before event %s could be processed", event.Token)
+			}
+
+			// Collect the token for verification.
+			mu.Lock()
+			tokens = append(tokens, event.Token)
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	// Verify that all tokens were processed in the expected order.
+	for _, event := range events {
+		event.Check(t, tokens)
+	}
+}
+
+// Event represents a step in a concurrent test that uses either
+// TotalOrder, PartialOrder, or CausalOrder to test the causal relationships
+// between operations.
+//
+// Each event has a token that identifies it, a list of dependencies that
+// represent other events that must complete before this event can be processed,
+// and an Operation that defines the "happens-after" relationship for this event.
+//
+// The ordering types are designed to compose dependencies before the processing
+// begins in separate goroutines, which is why definition functions (returning
+// the events of test-cases) can prepare the "happens-after" relationships
+// without actually executing the operations.
+//
+// The TestCase runner executes the operations themselves.
+type Event struct {
+	// Token is a unique identifier for this event, used to track its execution in
+	// the processing order and verify dependency constraints.
+	Token string
+
+	// HappensAfter lists the tokens of events that must complete before this event
+	// should've been processed. The test framework verifies that all dependencies
+	// appear before this event in the actual execution order.
+	HappensAfter []string
+
+	// Operation represents the ordering operation returned by the ordering types. It
+	// provides the synchronization mechanism to enforce the declared dependencies.
+	//
+	// The test framework waits on the [ordering.Operation.Ready] channel before
+	// processing the event, ensuring that declared dependencies are respected.
+	//
+	// The test framework calls [ordering.Operation.Complete] after processing each
+	// event to maintain the correctness of causal chains and prevent deadlocks.
+	Operation ordering.Operation
+}
+
+// Check verifies that all of this event's dependencies were processed before
+// this event in the given execution order.
+//
+// The tokens parameter should contain the ordered list of event tokens as they
+// were actually processed.
+//
+// This method will verify that:
+//   - This event's token appears in the recorded list of tokens.
+//   - All dependencies listed in HappensAfter appear before Token in the list.
+//
+// Any violations of the dependency constraints will be reported as test errors.
+func (e Event) Check(t *testing.T, tokens []string) {
+	t.Helper()
+
+	// Find the position of this event in the list of tokens.
+	eventIndex, ok := e.index(tokens)
+	if !ok {
+		t.Errorf("event %v was not processed", e.Token)
+		return
+	}
+
+	// Check that all dependencies appear before this event.
+	for _, dep := range e.HappensAfter {
+		found := false
+		for i := 0; i < eventIndex; i++ {
+			if tokens[i] == dep {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("event %v: dependency %v was not processed before it", e.Token, dep)
+		}
+	}
+}
+
+// Finds the index of this event's token in the given slice of tokens.
+func (e Event) index(tokens []string) (index int, found bool) {
+	for i, token := range tokens {
+		if token == e.Token {
+			return i, true
+		}
+	}
+	return 0, false
+}

--- a/ordering/ordertest/ordertest_test.go
+++ b/ordering/ordertest/ordertest_test.go
@@ -1,0 +1,132 @@
+package ordertest
+
+import (
+	"flag"
+	"testing"
+)
+
+func TestDisjointEvents(t *testing.T) {
+	// All disjoint events don't participate in any happens-after relationship. They
+	// should all be able to proceed immediately and in any order. As such, each
+	// Event's HappensAfter field is zero.
+	events := []Event{
+		{Token: "1", Operation: DetachedOp()},
+		{Token: "2", Operation: DetachedOp()},
+		{Token: "3", Operation: DetachedOp()},
+		{Token: "4", Operation: DetachedOp()},
+	}
+	// Calling ordertest.Test is the actual test since we provide a set of events
+	// that we know must pass. Calling ordertest.Test will fail the test if its
+	// implementation becomes incorrect and violates this expected behaviour.
+	Test(t, events)
+}
+
+func TestDependentEvents(t *testing.T) {
+	var chain TestChain
+	// Dependent events must respect their happens-after relationships. This test
+	// defines a simple linear chain of dependencies: 1 -> 2 -> 3 -> 4. As such,
+	// each Event's HappensAfter field contains the Token of the previous Event.
+	events := []Event{
+		{Token: "1", HappensAfter: nil, Operation: chain.Get(0)},
+		{Token: "2", HappensAfter: []string{"1"}, Operation: chain.Get(1)},
+		{Token: "3", HappensAfter: []string{"2"}, Operation: chain.Get(2)},
+		{Token: "4", HappensAfter: []string{"3"}, Operation: chain.Get(3)},
+	}
+	// Calling ordertest.Test is the actual test since we provide a set of events
+	// that we know must pass. Calling ordertest.Test will fail the test if its
+	// implementation becomes incorrect and violates this expected behaviour.
+	Test(t, events)
+}
+
+var xfail = flag.Bool("xfail", false, "run tests that are expected to fail")
+
+func TestBadOrdering(t *testing.T) {
+	// This test is expected to fail, so skip it unless explicitly requested with the
+	// -xfail flag, in which case we know the user intends to run it to see it fail.
+	if !*xfail {
+		t.Skip("Skipping test that is expected to fail; use -xfail to run it")
+	}
+
+	// This test describes the same linear chain of dependencies as
+	// TestDependentEvents, but the Events are set with disjoint operations that do
+	// not respect the declared happens-after relationships.
+	events := []Event{
+		{Token: "1", HappensAfter: nil, Operation: DetachedOp()},
+		{Token: "2", HappensAfter: []string{"1"}, Operation: DetachedOp()},
+		{Token: "3", HappensAfter: []string{"2"}, Operation: DetachedOp()},
+		{Token: "4", HappensAfter: []string{"3"}, Operation: DetachedOp()},
+	}
+	// This test is expected to fail when passed to ordertest.Test, demonstrating
+	// that it correctly identifies violations of the declared ordering constraints.
+	Test(t, events)
+}
+
+// TestOp is a simple implementation of the Operation interface for testing in
+// this package.
+//
+// It allows tests to describe different readiness and completion scenarios by
+// manually controlling the ready and completed channels.
+//
+// The DetachedOp and ChainedOp helpers initialize the TestOp in common states.
+type TestOp struct {
+	ready     <-chan struct{}
+	completed chan struct{}
+}
+
+// DetachedOp returns a TestOp that is ready immediately.
+func DetachedOp() *TestOp {
+	ch := make(chan struct{})
+	close(ch)
+	return &TestOp{ready: ch, completed: make(chan struct{})}
+}
+
+// Chain returns a TestOp that becomes ready after the given channel is closed.
+func ChainedOp(after <-chan struct{}) *TestOp {
+	return &TestOp{ready: after, completed: make(chan struct{})}
+}
+
+func (o *TestOp) Ready() <-chan struct{} {
+	return o.ready
+}
+
+func (o *TestOp) Completed() <-chan struct{} {
+	return o.completed
+}
+
+func (o *TestOp) Complete() {
+	close(o.completed)
+}
+
+// A TestChain is a helper for creating a sequence of testOps where each
+// operation depends on the completion of the previous operation in the chain.
+//
+// Calling ops.Get(n) returns the nth operation in the chain, creating it if it
+// doesn't already exist. Each operation's readiness depends on the completion of
+// the previous operation, forming a linear dependency chain.
+//
+// The first operation in the chain (ops.Get(0)) is ready immediately.
+type TestChain map[uint]*TestOp
+
+func (c *TestChain) Get(id uint) *TestOp {
+	// Make the zero TestChain usable.
+	if *c == nil {
+		*c = make(map[uint]*TestOp)
+	}
+	// Return the existing operation if it already exists.
+	if op, ok := (*c)[id]; ok {
+		return op
+	}
+	// Create a new operation, setting its readiness based on the previous
+	// operation in the chain.
+	op := c.new(id)
+	(*c)[id] = op
+	return op
+}
+
+func (c *TestChain) new(id uint) *TestOp {
+	if id == 0 {
+		// The first operation is ready immediately.
+		return DetachedOp()
+	}
+	return ChainedOp(c.Get(id - 1).Completed())
+}

--- a/ordering/partialorder/example_test.go
+++ b/ordering/partialorder/example_test.go
@@ -1,0 +1,109 @@
+package partialorder_test
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/notorious-go/sync/ordering/partialorder"
+)
+
+// This example demonstrates how to effectively process a stream of events with
+// partial causal ordering by showing a sample server that audits actions in the
+// correct order for the same user, even when processed concurrently.
+//
+// The [PartialOrder] and [Topic] types support any number of partitions,
+// allowing you to manage dynamic sets of dependent operations.
+//
+// When orchestration requires fine-grained control over the lifecycle of
+// operations, you can use the [PartialOrder] type directly. The [Topic] type is
+// a higher-level construct that demonstrates one way to expose a simpler API to
+// manage a group of goroutines with partitioned dependencies.
+func Example() {
+	// For this example, we will use a partial group (called a Topic) to ensure that
+	// actions for the same user are logged in order, even when started concurrently.
+	//
+	// Note that any comparable type can be used as a key for the PartialOrder.
+	//
+	// Note how the zero value of PartialOrder is ready to use.
+	var topic partialorder.Topic[string]
+
+	// This example uses a simple in-memory audit log to demonstrate the causal
+	// ordering of user actions.
+	var database AuditLog
+
+	for _, event := range EventSource {
+		// With a Topic, the Go method allows us to dynamically assign operations to
+		// specific keys (in this case, usernames) while managing concurrency and
+		// happens-after ordering.
+		//
+		// Without limits, Go spawns a new goroutine for each event and returns
+		// immediately. In a real application, you may want to set a limit on the number
+		// of active goroutines to avoid overwhelming the system, though it will not
+		// affect the correctness of the ordering.
+		topic.Go(event.User, func() {
+			// The given function is called only after all previous operations for the same
+			// user have completed. This is achieved by the Topic internally managing the
+			// PartialOrder and synchronizing the operations.
+			//
+			// After the internal Ready channel synchronizes, we know that no other goroutine
+			// is currently processing actions for the same user, so we can safely apply the
+			// change to the database without additional locking for the same user.
+			database.Append(event.User, event.Action)
+		})
+	}
+
+	// Just like with WaitGroup, we wait for all operations to complete before
+	// printing the database state.
+	topic.Wait()
+	fmt.Println(database.String())
+
+	// Unordered Output:
+	// User alice: [login binge logout]
+	// User bob: [login logout]
+}
+
+// EventSource is a sample log of user actions that we will use to demonstrate
+// causal ordering.
+//
+// This data is synthetic, but in a real application, it would come from an event
+// source like a message queue or a database change stream.
+//
+// Each action is associated with a user, and we want to ensure that actions for
+// the same user are audited in the order they were performed, even if the events
+// are processed concurrently.
+var EventSource = []struct {
+	User   string
+	Action string
+}{
+	{User: "alice", Action: "login"},
+	{User: "bob", Action: "login"},
+	{User: "alice", Action: "binge"},
+	{User: "bob", Action: "logout"},
+	{User: "alice", Action: "logout"},
+}
+
+// AuditLog is a simple in-memory log that records user actions in the order they
+// were appended. The Append method is thread-safe and allows concurrent
+// appending of actions by different users, and the String method returns a
+// formatted string representation of the log.
+type AuditLog struct {
+	m  map[string][]string
+	mu sync.Mutex
+}
+
+func (l *AuditLog) Append(user, action string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.m == nil {
+		l.m = make(map[string][]string)
+	}
+	l.m[user] = append(l.m[user], action)
+}
+
+func (l *AuditLog) String() string {
+	var s string
+	for user, actions := range l.m {
+		s += fmt.Sprintf("User %v: %v\n", user, actions)
+	}
+	return s
+}

--- a/ordering/partialorder/partialorder.go
+++ b/ordering/partialorder/partialorder.go
@@ -1,0 +1,144 @@
+package partialorder
+
+import (
+	"sync"
+
+	"github.com/notorious-go/sync/ordering"
+)
+
+// chain represents a linked list of operations for a single key
+type chain struct {
+	head chan struct{}
+}
+
+// init ensures that the chain is ready to use
+func (c *chain) init() {
+	if c.head == nil {
+		c.head = make(chan struct{})
+		close(c.head)
+	}
+}
+
+// advance creates a new head for the chain and returns the wait and done channels
+func (c *chain) advance() (wait <-chan struct{}, done chan struct{}) {
+	c.init()
+	wait = c.head
+	done = make(chan struct{})
+	c.head = done
+	return wait, done
+}
+
+// isHead checks if the given done channel is the current head of the chain
+func (c *chain) isHead(done chan struct{}) bool {
+	return c.head == done
+}
+
+// PartialOrder enforces a strict sequential ordering for operations with the
+// same key, while allowing operations with different keys to execute
+// concurrently. This is useful for scenarios where operations must be serialized
+// per key, such as when processing events that are grouped by an identifier.
+//
+// Operations added via HappensAfter will execute in the order they were added
+// for each key, but operations with different keys can run in parallel.
+//
+// The PartialOrder is not safe for concurrent use. It must be used from a single
+// goroutine that is responsible for managing the execution of operations
+// associated with it. This is because the order of operations is defined by the
+// order in which they are added to the PartialOrder.
+//
+// The zero-value PartialOrder is ready to use.
+type PartialOrder[K comparable] struct {
+	// Makes the zero-value PartialOrder ready to use and concurrent-safe.
+	initOnce sync.Once
+	// We must protect the map of chains against concurrent access.
+	chains chan map[K]*chain
+}
+
+// acquire gets exclusive access to the chains map
+func (o *PartialOrder[K]) acquire() (chains map[K]*chain, release func()) {
+	o.initOnce.Do(func() {
+		o.chains = make(chan map[K]*chain, 1)
+		o.chains <- make(map[K]*chain)
+	})
+	chains = <-o.chains
+	release = func() { o.chains <- chains }
+	return chains, release
+}
+
+// HappensAfter returns an Operation representing a unit of work that must execute
+// after all previously added operations for the given key have completed.
+// Operations with the same key are executed in the exact order that HappensAfter
+// was called, while operations with different keys may execute concurrently.
+//
+// The first operation for a given key proceeds immediately without waiting. Each
+// following operation for that key waits for its immediate predecessor with the
+// same key to call Complete() before it can proceed.
+//
+// IMPORTANT: The caller MUST call Complete() on the returned Operation when the
+// operation completes, even if the operation fails or is cancelled. Failing to
+// call Complete() will cause all subsequent operations for that key to block
+// indefinitely, which may result in memory leaks.
+//
+// When the last pending operation for a key completes, the key's internal chain
+// is automatically cleaned up to prevent memory leaks.
+//
+// Note that this package only provides ordering guarantees and does not
+// propagate cancellation signals between operations. If an operation needs to be
+// cancelled, the caller should implement their own cancellation mechanism (such
+// as using select with context.Done()) and ensure Complete() is still called to
+// unblock the following operations for that key.
+func (o *PartialOrder[K]) HappensAfter(key K) ordering.Operation {
+	chains, release := o.acquire()
+	defer release()
+
+	if _, exists := chains[key]; !exists {
+		chains[key] = new(chain)
+	}
+
+	wait, done := chains[key].advance()
+	return &partialOperation[K]{
+		wait:  wait,
+		done:  done,
+		key:   key,
+		order: o,
+	}
+}
+
+// delete removes the chain for the given key if the done channel is the head
+func (o *PartialOrder[K]) delete(key K, done chan struct{}) {
+	chains, release := o.acquire()
+	defer release()
+
+	if c, ok := chains[key]; ok && c.isHead(done) {
+		delete(chains, key)
+	}
+}
+
+type partialOperation[K comparable] struct {
+	wait <-chan struct{}
+	done chan struct{}
+	// The done channel must be closed only once. Without this flag, calling Complete()
+	// twice would've panicked because channels cannot be closed more than once.
+	doneOnce sync.Once
+	// The key with which this operation is associated in the namespace of chains.
+	key K
+	// The PartialOrder which this operation is associated with. When the operation is
+	// Complete() and no more operations are pending for this key, the chain will be
+	// deleted from this map.
+	order *PartialOrder[K]
+}
+
+func (h *partialOperation[K]) Ready() <-chan struct{} {
+	return h.wait
+}
+
+func (h *partialOperation[K]) Completed() <-chan struct{} {
+	return h.done
+}
+
+func (h *partialOperation[K]) Complete() {
+	h.doneOnce.Do(func() {
+		close(h.done)
+		h.order.delete(h.key, h.done)
+	})
+}

--- a/ordering/partialorder/partialorder_test.go
+++ b/ordering/partialorder/partialorder_test.go
@@ -1,0 +1,61 @@
+package partialorder_test
+
+import (
+	"testing"
+
+	"github.com/notorious-go/sync/ordering/ordertest"
+	"github.com/notorious-go/sync/ordering/partialorder"
+)
+
+// This test verifies two chains of operations ("alice" and "bob") to ensure that
+// operations within the same chain correctly adhere to the interface guarantees.
+func TestOperationInterface(t *testing.T) {
+	var order partialorder.PartialOrder[string]
+	t.Run("alice-in-chains", func(t *testing.T) {
+		first := order.HappensAfter("alice")
+		second := order.HappensAfter("alice")
+		ordertest.TestOperationInterface(t, first, second)
+	})
+	t.Run("bob-in-chains", func(t *testing.T) {
+		first := order.HappensAfter("bob")
+		second := order.HappensAfter("bob")
+		ordertest.TestOperationInterface(t, first, second)
+	})
+}
+
+func TestPartialOrdering(t *testing.T) {
+	var po partialorder.PartialOrder[string]
+	events := []ordertest.Event{
+		{
+			Token:        "alice:login",
+			HappensAfter: nil,
+			Operation:    po.HappensAfter("alice"),
+		},
+		{
+			Token:        "bob:login",
+			HappensAfter: nil,
+			Operation:    po.HappensAfter("bob"),
+		},
+		{
+			Token:        "alice:watch-reels",
+			HappensAfter: []string{"alice:login"},
+			Operation:    po.HappensAfter("alice"),
+		},
+		{
+			Token:        "bob:binge-reels",
+			HappensAfter: []string{"bob:login"},
+			Operation:    po.HappensAfter("bob"),
+		},
+		{
+			Token:        "alice:logout",
+			HappensAfter: []string{"alice:watch-reels"},
+			Operation:    po.HappensAfter("alice"),
+		},
+		{
+			Token:        "bob:logout",
+			HappensAfter: []string{"bob:binge-reels"},
+			Operation:    po.HappensAfter("bob"),
+		},
+	}
+	ordertest.Test(t, events)
+}

--- a/ordering/partialorder/topic.go
+++ b/ordering/partialorder/topic.go
@@ -1,0 +1,65 @@
+package partialorder
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/notorious-go/sync/ordering"
+	"github.com/notorious-go/sync/semaphore"
+)
+
+// A Topic is a collection of goroutines working on tasks that maintain a partial
+// order of execution based on their partition key. Each task blocks until all
+// previously submitted tasks with the same partition key have completed.
+//
+// Unlike Queue, which blocks until all previous tasks are complete, Topic only
+// blocks on tasks within the same partition, allowing unrelated operations to
+// proceed without blocking on each other.
+//
+// A zero Topic is valid and has no limit on the number of active goroutines.
+type Topic[K comparable] struct {
+	wg       sync.WaitGroup
+	sem      semaphore.Semaphore
+	ordering PartialOrder[K]
+}
+
+// Go calls the given function in a new goroutine. It blocks until the new
+// goroutine can be added without the number of active goroutines in the group
+// exceeding the configured limit.
+//
+// The new goroutine will block before calling f until all previously submitted
+// tasks with the same partition key have completed. Tasks with different
+// partition keys do not block on each other.
+func (t *Topic[K]) Go(partition K, f func()) {
+	op := t.ordering.HappensAfter(partition)
+	t.sem.Acquire()
+	t.wg.Add(1)
+	go func() {
+		defer t.done(op)
+		<-op.Ready()
+		f()
+	}()
+}
+
+func (t *Topic[K]) done(op ordering.Operation) {
+	op.Complete()
+	t.sem.Release()
+	t.wg.Done()
+}
+
+// Wait blocks until all function calls from the Go method have returned.
+func (t *Topic[K]) Wait() {
+	t.wg.Wait()
+}
+
+// SetLimit limits the number of active goroutines in this group to at most n. A
+// negative value indicates no limit. A zero value will block any further calls
+// to Go.
+//
+// The limit must not be modified while any goroutines in the group are active.
+func (t *Topic[K]) SetLimit(n int) {
+	if len(t.sem) != 0 {
+		panic(fmt.Errorf("topic: modify limit while %v goroutines in the group are still active", len(t.sem)))
+	}
+	t.sem = semaphore.New(n)
+}

--- a/ordering/partialorder/topic_test.go
+++ b/ordering/partialorder/topic_test.go
@@ -1,0 +1,66 @@
+package partialorder_test
+
+import (
+	"fmt"
+
+	"github.com/notorious-go/sync/ordering/partialorder"
+)
+
+// This example demonstrates using Topic to process events partitioned by a key,
+// where events with the same key execute sequentially, but events with different
+// keys can execute concurrently.
+func ExampleTopic() {
+	// The zero value of Topic is valid and has no limit on the number of active
+	// goroutines.
+	var topic partialorder.Topic[string]
+
+	// Simulate processing user actions where each user's actions must be processed
+	// in order, but different users can have their actions processed concurrently.
+	events := []struct {
+		User   string
+		Action string
+	}{
+		{"alice", "login"},
+		{"bob", "login"},
+		{"alice", "watch-some-reels"},
+		{"bob", "binge-some-reels"},
+		{"bob", "logout"},
+		{"alice", "logout"},
+	}
+
+	// Since users are processed concurrently with each other, we cannot guarantee a
+	// constant output for this example, so we record the order of actions for each user
+	// individually to verify that each user's actions are processed sequentially.
+	//
+	// We use two slices without locks because the Topic guarantees that actions for
+	// the same user will not interleave, so we can safely append to the slices
+	// without additional synchronization.
+	var alice, bob []string
+	for _, event := range events {
+		topic.Go(event.User, func() {
+			switch event.User {
+			case "alice":
+				alice = append(alice, event.Action)
+			case "bob":
+				bob = append(bob, event.Action)
+			default:
+				panic(fmt.Sprintf("unexpected user: %s", event.User))
+			}
+		})
+	}
+
+	// After submitting all events, we wait for all goroutines in the topic to
+	// complete.
+	topic.Wait()
+	fmt.Println("All user events processed")
+
+	// Verify that actions for each user were processed in order by
+	// printing the collected actions for each user.
+	fmt.Printf("Alice's actions: %v\n", alice)
+	fmt.Printf("Bob's actions: %v\n", bob)
+
+	// Output:
+	// All user events processed
+	// Alice's actions: [login watch-some-reels logout]
+	// Bob's actions: [login binge-some-reels logout]
+}

--- a/ordering/totalorder/queue.go
+++ b/ordering/totalorder/queue.go
@@ -1,0 +1,60 @@
+package totalorder
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/notorious-go/sync/ordering"
+	"github.com/notorious-go/sync/semaphore"
+)
+
+// A Queue is a collection of goroutines working on tasks that must maintain a
+// strict total order. Each task blocks until all previously submitted tasks have
+// completed their execution.
+//
+// A zero Queue is valid and has no limit on the number of active goroutines.
+type Queue struct {
+	wg       sync.WaitGroup
+	sem      semaphore.Semaphore
+	ordering TotalOrder
+}
+
+// Go calls the given function in a new goroutine. It blocks until the new
+// goroutine can be added without the number of active goroutines in the group
+// exceeding the configured limit.
+//
+// The new goroutine will block before calling f until all previously submitted
+// tasks have completed, ensuring a strict sequential execution order.
+func (q *Queue) Go(f func()) {
+	op := q.ordering.HappensNext()
+	q.sem.Acquire()
+	q.wg.Add(1)
+	go func() {
+		defer q.done(op)
+		<-op.Ready()
+		f()
+	}()
+}
+
+func (q *Queue) done(op ordering.Operation) {
+	op.Complete()
+	q.sem.Release()
+	q.wg.Done()
+}
+
+// Wait blocks until all function calls from the Go method have returned.
+func (q *Queue) Wait() {
+	q.wg.Wait()
+}
+
+// SetLimit limits the number of active goroutines in this group to at most n. A
+// negative value indicates no limit. A zero value will block any further calls
+// to Go.
+//
+// The limit must not be modified while any goroutines in the group are active.
+func (q *Queue) SetLimit(n int) {
+	if len(q.sem) != 0 {
+		panic(fmt.Errorf("queue: modify limit while %v goroutines in the group are still active", len(q.sem)))
+	}
+	q.sem = semaphore.New(n)
+}

--- a/ordering/totalorder/queue_test.go
+++ b/ordering/totalorder/queue_test.go
@@ -1,0 +1,36 @@
+package totalorder_test
+
+import (
+	"fmt"
+
+	"github.com/notorious-go/sync/ordering/totalorder"
+)
+
+// This example demonstrates using Queue to process events in strict sequential
+// order, ensuring that each event is fully processed before the next one begins.
+func ExampleQueue() {
+	// The zero value of Queue is valid and has no limit on the number of active
+	// goroutines.
+	var queue totalorder.Queue
+
+	// Simulate processing a series of database migrations that must run in order.
+	migrations := []string{"create_users", "add_email_index", "create_posts", "add_foreign_keys"}
+	for i, migration := range migrations {
+		queue.Go(func() {
+			// Simulate migration work
+			fmt.Printf("Running migration %d: %s\n", i+1, migration)
+		})
+	}
+
+	// After submitting all migrations, we wait for all goroutines in the queue to
+	// complete.
+	queue.Wait()
+	fmt.Println("All migrations completed")
+
+	// Output:
+	// Running migration 1: create_users
+	// Running migration 2: add_email_index
+	// Running migration 3: create_posts
+	// Running migration 4: add_foreign_keys
+	// All migrations completed
+}

--- a/ordering/totalorder/totalorder.go
+++ b/ordering/totalorder/totalorder.go
@@ -1,0 +1,114 @@
+package totalorder
+
+import (
+	"sync"
+
+	"github.com/notorious-go/sync/ordering"
+)
+
+// TotalOrder enforces a strict sequential ordering of all associated operations.
+// This is useful when operations must be serialized globally, regardless of
+// their keys or other attributes.
+//
+// Operations added via HappensNext will execute one at a time in the order they
+// were added.
+//
+// Though trivial, this ordering is useful for composing more complex
+// synchronization constructs that apply several total orders.
+//
+// Most linear chains of operations are better serialized using mutexes,
+// channels, or other synchronization primitives. Nonetheless, TotalOrder
+// presents a unique synchronization style applicable when operations have a
+// definite order of execution and must be serialized.
+//
+// For example, consider concurrent database writes. If only one write operation
+// is allowed to execute at a time, use a semaphore or a mutex to limit
+// concurrency when writing to the database. However, if the order of writing ops
+// matters, use TotalOrder to ensure that writes are executed in the order they
+// were added, while spawning goroutines for each writer.
+//
+// The TotalOrder is not safe for concurrent use. It must be used from a single
+// goroutine that is responsible for defining the definitive order of operations.
+// Per the explanation above, it would be meaningless to use it concurrently
+// because the order would not be well-defined, thus violating the strictness of
+// the total order.
+//
+// The zero-value TotalOrder is ready to use.
+type TotalOrder struct {
+	// head is the head of the chain, representing the most recently added operation.
+	// It starts as nil and is initialized to a closed channel on first use.
+	head chan struct{}
+}
+
+// init ensures that the TotalOrder is ready to use. It is safe to call init
+// multiple times.
+//
+// Upon the first call, it sets the head of the chain to a closed channel,
+// marking the next operation (by calling HappensNext) as ready to execute
+// immediately. Further calls do nothing, as the chain is already initialized.
+func (o *TotalOrder) init() {
+	// Every new chain starts with a single node, which is closed immediately to
+	// signal readiness.
+	if o.head == nil {
+		o.head = make(chan struct{})
+		close(o.head)
+	}
+}
+
+// HappensNext returns an Operation representing a unit of work that must execute
+// after all previously added operations have completed. Operations are executed
+// in the exact order that HappensNext was called.
+//
+// The first operation added to a TotalOrder proceeds immediately without
+// waiting. Each following operation waits for its immediate predecessor to call
+// Complete() before it can proceed.
+//
+// IMPORTANT: The caller MUST call Complete() on the returned Operation when the
+// operation completes, even if the operation fails or is cancelled. Failing to
+// call Complete() will cause all subsequent operations to block indefinitely, which
+// may result in memory leaks.
+//
+// Note that this package only provides ordering guarantees and does not
+// propagate cancellation signals between operations. If an operation needs to be
+// cancelled, the caller should implement their own cancellation mechanism (such
+// as using select with context.Done()) and ensure Complete() is still called to
+// unblock the following operations in the chain.
+func (o *TotalOrder) HappensNext() ordering.Operation {
+	o.init()
+	wait := o.head
+	done := make(chan struct{})
+	o.head = done
+	return &totalOperation{
+		wait: wait,
+		done: done,
+	}
+}
+
+// A totalOperation implements the ordering.Operation interface for a single totally
+// ordered chain of operations.
+type totalOperation struct {
+	// The wait channel is closed when the previous operation in the chain has
+	// completed, allowing this operation to proceed.
+	wait <-chan struct{}
+	// The done channel is used to signal that the operation associated with this
+	// node has completed, thereby allowing the next operation in the chain to
+	// proceed.
+	done chan struct{}
+	// The done channel must be closed only once. Without this flag, calling Complete()
+	// twice would've panicked because channels cannot be closed more than once.
+	doneOnce sync.Once
+}
+
+func (h *totalOperation) Ready() <-chan struct{} {
+	return h.wait
+}
+
+func (h *totalOperation) Completed() <-chan struct{} {
+	return h.done
+}
+
+func (h *totalOperation) Complete() {
+	h.doneOnce.Do(func() {
+		close(h.done)
+	})
+}

--- a/ordering/totalorder/totalorder_test.go
+++ b/ordering/totalorder/totalorder_test.go
@@ -1,0 +1,28 @@
+package totalorder_test
+
+import (
+	"testing"
+
+	"github.com/notorious-go/sync/ordering/ordertest"
+	"github.com/notorious-go/sync/ordering/totalorder"
+)
+
+func TestOperationInterface(t *testing.T) {
+	var order totalorder.TotalOrder
+	first := order.HappensNext()
+	second := order.HappensNext()
+	ordertest.TestOperationInterface(t, first, second)
+}
+
+func TestTotalOrderings(t *testing.T) {
+	var alice, bob totalorder.TotalOrder
+	events := []ordertest.Event{
+		{Token: "A1", HappensAfter: nil, Operation: alice.HappensNext()},
+		{Token: "B1", HappensAfter: nil, Operation: bob.HappensNext()},
+		{Token: "A2", HappensAfter: []string{"A1"}, Operation: alice.HappensNext()},
+		{Token: "B2", HappensAfter: []string{"B1"}, Operation: bob.HappensNext()},
+		{Token: "A3", HappensAfter: []string{"A2"}, Operation: alice.HappensNext()},
+		{Token: "B3", HappensAfter: []string{"B2"}, Operation: bob.HappensNext()},
+	}
+	ordertest.Test(t, events)
+}


### PR DESCRIPTION
This change addresses Issue #8 by introducing a first‑class, composable way to express execution ordering in concurrent workflows. Today, ad‑hoc mixes of mutexes, channels, and WaitGroups make correctness and composition difficult; the goal here is to make ordering explicit, cheap, and uniform across the three common shapes we use: strict global sequencing, per‑key sequencing, and multi‑dependency (causal) relationships. Closes #8.

The new `ordering` package defines a minimal `Operation` interface and helpers (`Ready`, `Completed`, `Await`) to model happens‑after relationships. Three subpackages implement concrete strategies: `totalorder` for strict global sequencing, `partialorder` for per‑key sequencing with cross‑key concurrency, and `causalorder` for multi‑dependency graphs. Each strategy includes a group type that pairs ordering with bounded concurrency and goroutine lifecycle management: `totalorder.Queue`, `partialorder.Topic[K]`, and `causalorder.DependencyGraph[K]`. Documentation in `doc.go` covers usage, best practices, and how to choose a strategy; tests and examples exercise sequential, per‑key, and multi‑dependency scenarios. Module metadata (`go.mod`) depends on `github.com/notorious-go/sync/semaphore v1.0.0` and has been tidied.

### Design Notes
Zero‑values are usable across all types. Ordering objects are single‑producer to keep the ordering semantics well‑defined. Chains are reclaimed automatically when no more operations are pending to avoid leaks. The causal implementation short‑circuits readiness when dependencies are already satisfied to reduce allocations and goroutine overhead.

### Backwards Compatibility
This is additive: it introduces a new package and subpackages without modifying existing APIs.

### Next Steps
In `causalorder/example_test.go`, there is a TODO noting that combinedOp is not immediately marked as ready because the internal state update happens asynchronously; this will be fixed in a future release.
